### PR TITLE
Don't use dots for Brewfile

### DIFF
--- a/rcrc
+++ b/rcrc
@@ -1,2 +1,3 @@
 EXCLUDES="README.md LICENSE"
 DOTFILES_DIRS="$HOME/.dotfiles"
+UNDOTTED="Brewfile"

--- a/zshrc
+++ b/zshrc
@@ -50,3 +50,5 @@ setopt auto_cd
 cdpath=($HOME/Projects)
 
 source "/usr/local/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+
+export PATH="$HOME/.bin:$PATH"


### PR DESCRIPTION
While it wouldn't be the worst thing in the world to point to a dotted
Brewfile, it just feels wrong.