### PR TITLE
Add `git trust-bin` command

### DIFF
--- a/bin/git-trust-bin
+++ b/bin/git-trust-bin
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+mkdir -p .git/safe


### PR DESCRIPTION
Following thoughtbot's lead, it is not appropriate to use .git/safe in
an automatic setup script.  Developers should manually review scripts
before trusting them.

Add `git trust-bin` command to make it easier to trust a project after
reviewing the scripts.

See thoughtbot dotfiles commit adding trust-bin command:
https://github.com/thoughtbot/dotfiles/commit/384d4ad5e63ff60a63271b625d39088086abb4c4#diff-90e5dba1c84068e890c0b113da74e573